### PR TITLE
Fix nullpointer on constructionSite check

### DIFF
--- a/eisbw/src/main/java/eisbw/Game.java
+++ b/eisbw/src/main/java/eisbw/Game.java
@@ -70,7 +70,7 @@ public class Game {
     Map<String, StarcraftUnit> unitList = units.getStarcraftUnits();
     for (Entry<String, StarcraftUnit> unit : unitList.entrySet()) {
       Map<PerceptFilter, List<Percept>> thisUnitPercepts = new HashMap<>(perceptHolder);
-      if (getUnits().getUnits().get(unit.getKey()).getType().isWorker()) {
+      if (unit.getValue().isWorker()) {
         thisUnitPercepts.putAll(constructionPercepts);
       }
       thisUnitPercepts.putAll(mapPercepts);

--- a/eisbw/src/main/java/eisbw/units/StarcraftUnit.java
+++ b/eisbw/src/main/java/eisbw/units/StarcraftUnit.java
@@ -16,13 +16,16 @@ import java.util.Map;
 public class StarcraftUnit {
 
   protected final List<IPerceiver> perceivers;
+  private boolean worker;
 
   /**
    * A starcraft unit with perceivers.
    * @param perceivers - list with perceivers to percept from.
+   * @param worker 
    */
-  public StarcraftUnit(List<IPerceiver> perceivers) {
+  public StarcraftUnit(List<IPerceiver> perceivers, boolean worker) {
     this.perceivers = perceivers;
+    this.worker = worker;
   }
 
   /**
@@ -40,5 +43,9 @@ public class StarcraftUnit {
     percepts.add(new ConditionPercept(conditions));
     toReturn.put(new PerceptFilter(Percepts.CONDITION, Filter.Type.ON_CHANGE), percepts);
     return toReturn;
+  }
+
+  public boolean isWorker() {
+    return worker;
   }
 }

--- a/eisbw/src/main/java/eisbw/units/StarcraftUnitFactory.java
+++ b/eisbw/src/main/java/eisbw/units/StarcraftUnitFactory.java
@@ -42,6 +42,6 @@ public class StarcraftUnitFactory {
       perceptGenerators.add(new WorkerPerceiver(api, unit));
     }
 
-    return new StarcraftUnit(perceptGenerators);
+    return new StarcraftUnit(perceptGenerators, unit.getType().isWorker());
   }
 }

--- a/eisbw/src/test/java/eisbw/units/StarcraftUnitTest.java
+++ b/eisbw/src/test/java/eisbw/units/StarcraftUnitTest.java
@@ -1,6 +1,7 @@
 package eisbw.units;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.when;
 
@@ -42,12 +43,13 @@ public class StarcraftUnitTest {
     when(perceiver.getConditions()).thenReturn(params);
     List<IPerceiver> list = new LinkedList<>();
     list.add(perceiver);
-    unit = new StarcraftUnit(list);
+    unit = new StarcraftUnit(list,false);
   }
 
   @Test
   public void test() {
     assertEquals(1,unit.perceive().size());
+    assertFalse(unit.isWorker());
   }
 
 }

--- a/eisbw/src/test/java/eisbw/units/UnitsTest.java
+++ b/eisbw/src/test/java/eisbw/units/UnitsTest.java
@@ -45,7 +45,7 @@ public class UnitsTest {
     when(unit.getID()).thenReturn(0);
 
     when(factory.create(any(Unit.class)))
-        .thenReturn(new StarcraftUnit(new LinkedList<IPerceiver>()));
+        .thenReturn(new StarcraftUnit(new LinkedList<IPerceiver>(),false));
 
     units = new Units(env);
   }


### PR DESCRIPTION
A nullpointer was thrown from a concurrency bug, fixed it.