### PR TITLE
Allow multiple managers to debugdraw at the same time

### DIFF
--- a/eisbw/src/main/java/eisbw/BwapiAction.java
+++ b/eisbw/src/main/java/eisbw/BwapiAction.java
@@ -4,12 +4,18 @@ import eis.iilang.Action;
 import jnibwapi.Unit;
 
 public class BwapiAction {
+	private final String agentName;
 	private final Unit unit;
 	private final Action action;
 
-	public BwapiAction(Unit unit, Action action) {
+	public BwapiAction(String agentName, Unit unit, Action action) {
+		this.agentName = agentName;
 		this.unit = unit;
 		this.action = action;
+	}
+
+	public String getAgentName() {
+		return agentName;
 	}
 
 	public Unit getUnit() {
@@ -24,6 +30,7 @@ public class BwapiAction {
 	public int hashCode() {
 		final int prime = 31;
 		int result = 1;
+		result = prime * result + ((this.agentName == null) ? 0 : this.agentName.hashCode());
 		result = prime * result + ((this.action == null) ? 0 : this.action.hashCode());
 		result = prime * result + ((this.unit == null) ? 0 : this.unit.hashCode());
 		return result;
@@ -37,6 +44,13 @@ public class BwapiAction {
 			return false;
 		}
 		BwapiAction other = (BwapiAction) obj;
+		if (this.agentName == null) {
+			if (other.agentName != null) {
+				return false;
+			}
+		} else if (!this.agentName.equals(other.agentName)) {
+			return false;
+		}
 		if (this.action == null) {
 			if (other.action != null) {
 				return false;

--- a/eisbw/src/main/java/eisbw/BwapiListener.java
+++ b/eisbw/src/main/java/eisbw/BwapiListener.java
@@ -51,7 +51,7 @@ public class BwapiListener extends BwapiEvents {
 	 *
 	 * @param game
 	 *            - the game data class
-	 * @param debugmode
+	 * @param debug
 	 *            - true iff debugger should be attached
 	 */
 	public BwapiListener(Game game, String scDir, boolean debug, boolean drawMapInfo, boolean drawUnitInfo,
@@ -150,7 +150,7 @@ public class BwapiListener extends BwapiEvents {
 			BwapiAction act = actions.next();
 			StarcraftAction action = this.actionProvider.getAction(act.getAction());
 			if (action != null) {
-				action.execute(act.getUnit(), act.getAction());
+				action.execute(act);
 			}
 			actions.remove();
 		}
@@ -240,7 +240,7 @@ public class BwapiListener extends BwapiEvents {
 	 *
 	 * @param name
 	 *            - the name of the unit.
-	 * @param act
+	 * @param action
 	 *            - the action.
 	 * @throws ActException
 	 *             - mandatory from EIS
@@ -248,7 +248,7 @@ public class BwapiListener extends BwapiEvents {
 	public void performEntityAction(String name, Action action) throws ActException {
 		Unit unit = this.game.getUnit(name); // can be null for the mapagent
 		if (isSupportedByEntity(action, name)) {
-			BwapiAction apiAction = new BwapiAction(unit, action);
+			BwapiAction apiAction = new BwapiAction(name, unit, action);
 			this.pendingActions.add(apiAction);
 		} else {
 			this.logger.log(Level.WARNING,

--- a/eisbw/src/main/java/eisbw/actions/DebugDraw.java
+++ b/eisbw/src/main/java/eisbw/actions/DebugDraw.java
@@ -1,18 +1,17 @@
 package eisbw.actions;
 
-import java.util.List;
-
-import org.apache.commons.lang3.StringEscapeUtils;
-
 import eis.iilang.Action;
 import eis.iilang.Parameter;
-import eisbw.BwapiUtility;
+import eisbw.BwapiAction;
 import eisbw.Game;
 import eisbw.debugger.draw.CustomDrawUnit;
 import eisbw.debugger.draw.IDraw;
 import jnibwapi.JNIBWAPI;
 import jnibwapi.Unit;
 import jnibwapi.types.UnitType;
+import org.apache.commons.lang3.StringEscapeUtils;
+
+import java.util.List;
 
 /**
  * @author Danny & Harm - Enable or disable drawing text above a certain unit.
@@ -46,11 +45,16 @@ public class DebugDraw extends StarcraftAction {
 
 	@Override
 	public void execute(Unit unit, Action action) {
-		List<Parameter> parameters = action.getParameters();
-		String text = StringEscapeUtils.unescapeJava(parameters.get(0).toProlog());
-		String name = (unit == null) ? "" : BwapiUtility.getName(unit);
+		// Empty, since we override execute(BwapiAction).
+	}
 
-		IDraw draw = new CustomDrawUnit(this.game, unit, text);
+	@Override
+	public void execute(BwapiAction action) {
+		List<Parameter> parameters = action.getAction().getParameters();
+		String text = StringEscapeUtils.unescapeJava(parameters.get(0).toProlog());
+		String name = action.getAgentName();
+
+		IDraw draw = new CustomDrawUnit(this.game, action.getUnit(), text);
 		this.game.addDraw(name, draw);
 		if (!text.isEmpty()) {
 			this.game.toggleDraw(name);

--- a/eisbw/src/main/java/eisbw/actions/StarcraftAction.java
+++ b/eisbw/src/main/java/eisbw/actions/StarcraftAction.java
@@ -1,6 +1,7 @@
 package eisbw.actions;
 
 import eis.iilang.Action;
+import eisbw.BwapiAction;
 import eisbw.BwapiUtility;
 import jnibwapi.JNIBWAPI;
 import jnibwapi.Unit;
@@ -65,6 +66,18 @@ public abstract class StarcraftAction {
 	 *            The evaluated action.
 	 */
 	public abstract void execute(Unit unit, Action action);
+
+	/**
+	 * Executes this action with the specified BwapiAction. Can be
+	 * overridden by subclasses if they need access to the raw
+	 * BwapiAction object.
+	 *
+	 * @param action
+	 *              The action to execute.
+	 */
+	public void execute(BwapiAction action) {
+		this.execute(action.getUnit(), action.getAction());
+	}
 
 	@Override
 	public abstract String toString();

--- a/eisbw/src/test/java/eisbw/BwapiListenerTest.java
+++ b/eisbw/src/test/java/eisbw/BwapiListenerTest.java
@@ -119,10 +119,10 @@ public class BwapiListenerTest {
 
 	@Test
 	public void matchFrame_test() throws ActException {
-		this.listener.pendingActions.add(new BwapiAction(new Unit(1, null), new Action("stub")));
-		this.listener.pendingActions.add(new BwapiAction(new Unit(2, null), new Action("stub")));
-		this.listener.pendingActions.add(new BwapiAction(new Unit(3, null), new Action("stub")));
-		this.listener.pendingActions.add(new BwapiAction(new Unit(4, null), new Action("stub")));
+		this.listener.pendingActions.add(new BwapiAction("unit_0", new Unit(1, null), new Action("stub")));
+		this.listener.pendingActions.add(new BwapiAction("unit_1", new Unit(2, null), new Action("stub")));
+		this.listener.pendingActions.add(new BwapiAction("unit_2", new Unit(3, null), new Action("stub")));
+		this.listener.pendingActions.add(new BwapiAction("unit_3", new Unit(4, null), new Action("stub")));
 		this.listener.matchFrame();
 		verify(this.game, times(1)).updateConstructionSites(this.bwapi);
 		when(this.bwapi.getFrameCount()).thenReturn(50);


### PR DESCRIPTION
Previously, the `IDraw` name for a manager would be `""`, which meant that only a single manager could `debugdraw(Text)` at a time. I've implemented it in the simplest way possible, by adding an optionally overridable method in `StarcraftAction` that gives access to the entire `BwapiAction`, instead of changing all actions to also take a `String agentName`. The new implementation has the `IDraw` name set to the name of the agent, which should be fine since it doesn't conflict with any other draws. 